### PR TITLE
Aplicando modelo OGM para Licitacao

### DIFF
--- a/back-end/api.py
+++ b/back-end/api.py
@@ -86,6 +86,13 @@ class ParticipanteEspecifico(Resource):
       '''
       return jsonify(dao.get_participante_por_codigo(id))
 
+@api.route("/api/unidades_gestoras")
+class UnidadesGest(Resource):
+   def get(self):
+      '''
+      Retorna uma lista com os nomes e os códigos das unidades gestoras
+      '''
+      return jsonify(dao.get_unidades_e_codigos())
 
 @app.route('/api')
 def olar():

--- a/back-end/banco.py
+++ b/back-end/banco.py
@@ -1,5 +1,5 @@
 from py2neo import Graph
-from models import Licitacao, Participante
+from models import Licitacao, Participante, UnidadeGestora
 import config as cfg
 
 class Dao:
@@ -31,6 +31,16 @@ class Dao:
         
         return(nodes)
 
+    def get_unidades_e_codigos(self):
+        result = UnidadeGestora.match(self.graph)
+        nodes = []
+            
+        for uni in result:
+            node = uni.__node__
+            if uni.nome_unidade_gestora != None:
+                nodes.append(node)
+
+        return nodes
     
     def get_licitacao_especifica(self, codUnidadeGestora, codTipoLicitacao, codLicitacao):
         result = self.graph.run("MATCH (l:Licitacao) WHERE l.CodUnidadeGest='{}' AND l.CodTipoLicitacao='{}' AND l.CodLicitacao='{}' RETURN l ".format(codUnidadeGestora, codTipoLicitacao, codLicitacao))
@@ -40,6 +50,7 @@ class Dao:
 
     def procurando_propostas(self, codUnidadeGestora, codLicitacao, codTipoLicitacao, pagina, limite):
         skip = limite * (pagina - 1)
+
         result = self.graph.run("MATCH p=()-[r:FEZ_PROPOSTA_EM]->() WHERE r.CodUnidadeGest='{}' and r.CodTipoLicitacao='{}' and r.CodLicitacao='{}'  RETURN r SKIP {} LIMIT {}".format(codUnidadeGestora, codTipoLicitacao, codLicitacao, skip, limite))
         nodes = [n for n in result]
         return nodes

--- a/back-end/models.py
+++ b/back-end/models.py
@@ -26,3 +26,13 @@ class Participante(GraphObject):
 
     def __iter__(self):
         return self.__node__
+
+
+class UnidadeGestora(GraphObject):
+    cod_unidade_gestora = Property("CodUnidadeGest")
+    nome_unidade_gestora = Property("NomeUnidadeGest")
+
+    realizou = RelatedTo("Licitacao", "REALIZOU")
+
+    def __iter__(self):
+        return self.__node__


### PR DESCRIPTION
Para facilitar a forma como objetos são convertidos do Neo4J para Python, foi usado o modelo Object Graph Model (OGM) para que essa conversão seja automática. Assim fica mais fácil acessar atributos e realizar buscas no Neo4J a partir de objetos convertidos automaticamente.