### PR TITLE
Tornar flask acessível externamente

### DIFF
--- a/back-end/api.py
+++ b/back-end/api.py
@@ -100,4 +100,4 @@ def olar():
    return "inicio"
    
 
-app.run(debug=True)
+app.run(host= '0.0.0.0', debug=True)


### PR DESCRIPTION
Adicionar parâmetro host=0.0.0.0 para permitir que a API REST em Flask seja acessível externamente.