### PR TITLE
Consertando acesso ao Swagger

### DIFF
--- a/back-end/api.py
+++ b/back-end/api.py
@@ -1,17 +1,20 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, Blueprint
 from banco import Dao
 from flask_cors import CORS
 from flask_restplus import Api, Resource
 
-
 app = Flask(__name__)
-api = Api(app=app, doc='/docs')
+
+blueprint = Blueprint('api', __name__, url_prefix='/api')
+api = Api(blueprint, doc='/docs')
+
+app.register_blueprint(blueprint)
 
 CORS(app, resources=r"/api/*", headers="Content-Type")
 
 dao = Dao()
 
-@api.route("/api/licitacoes")
+@api.route("/licitacoes")
 @api.doc(params={"ano": "Ano das licitações"})
 @api.doc(params={"codUni": "Código da unidade gestora"})
 @api.doc(params={"tipoLic": "Código do tipo da licitação"})
@@ -30,7 +33,7 @@ class Licitacao(Resource):
       return jsonify(dao.get_licitacoes(ano, tipoLic, codUni, pagina, limite))
 
 
-@api.route("/api/licitacoes/<string:id>/propostas")
+@api.route("/licitacoes/<string:id>/propostas")
 @api.doc(params={'pagina': 'Página que será acessada'})
 @api.doc(params={'limite': 'Quantos resultados serão retornados'})
 class Propostas(Resource):
@@ -49,7 +52,7 @@ class Propostas(Resource):
 
       return jsonify(dao.procurando_propostas(codUnidadeGestora, codLicitacao, codTipoLicitacao, pagina, limite))
 
-@api.route("/api/licitacoes/<string:id>")
+@api.route("/licitacoes/<string:id>")
 class LicitacaoEspecifica(Resource):
    def get(self, id):
       '''
@@ -63,7 +66,7 @@ class LicitacaoEspecifica(Resource):
       return jsonify(dao.get_licitacao_especifica(codUnidadeGestora, codTipoLicitacao, codLicitacao))
 
 
-@api.route("/api/participantes")
+@api.route("/participantes")
 @api.doc(params={'pagina': 'Página que será acessada'})
 @api.doc(params={'limite': 'Quantos resultados serão retornados'})
 class Participante(Resource):
@@ -77,7 +80,7 @@ class Participante(Resource):
       limite = request.args.get("limite", 20, int)
       return jsonify(dao.get_participantes(pagina, limite))
 
-@api.route("/api/participantes/<string:id>")
+@api.route("/participantes/<string:id>")
 @api.doc(params={'id': 'CPF/CNPJ do participante'})
 class ParticipanteEspecifico(Resource):
    def get(self, id):
@@ -86,7 +89,7 @@ class ParticipanteEspecifico(Resource):
       '''
       return jsonify(dao.get_participante_por_codigo(id))
 
-@api.route("/api/unidades_gestoras")
+@api.route("/unidades_gestoras")
 class UnidadesGest(Resource):
    def get(self):
       '''
@@ -94,10 +97,4 @@ class UnidadesGest(Resource):
       '''
       return jsonify(dao.get_unidades_e_codigos())
 
-@app.route('/api')
-def olar():
-   dao.gerando_query_participante("35422468000159", 1, 10)
-   return "inicio"
-   
-
-app.run(host= '0.0.0.0', debug=True)
+app.run(host = '0.0.0.0', debug=True)


### PR DESCRIPTION
Quando ele está por trás de um proxy (Apache / NGINX), o swagger não fica acessível. Tem que criar um Blueprint para resolver, como descrito aqui: https://flask-restplus.readthedocs.io/en/stable/swagger.html#customization