### PR TITLE
Flask acessivel externamente

### DIFF
--- a/back-end/api.py
+++ b/back-end/api.py
@@ -1,43 +1,15 @@
-from flask import Flask, jsonify, request, Blueprint, url_for
+from flask import Flask, jsonify, request, Blueprint
 from banco import Dao
 from flask_cors import CORS
-from flask_restplus import Api, Resource, apidoc
-import os
+from flask_restplus import Api, Resource
 
 app = Flask(__name__)
 
-custom_apidoc = apidoc.Apidoc('restplus_custom_doc', __name__,
-                              template_folder='templates',
-                              static_folder=os.path.dirname(apidoc.__file__) + '/static',
-                              static_url_path='/swaggerui')
-
-@custom_apidoc.add_app_template_global
-def swagger_static(filename):
-    return url_for('restplus_custom_doc.static',
-                   filename='bower/swagger-ui/dist/{0}'.format(filename))
-
-app.register_blueprint(custom_apidoc, url_prefix='/api/docs')
-
-
-class Custom_API(Api):
-     @property
-     def specs_url(self):
-         '''
-         The Swagger specifications absolute url (ie. `swagger.json`)
-
-         :rtype: str
-         '''
-         return url_for(self.endpoint('specs'), _external=False)
-
-
-# app = Flask(__name__)
-
-blueprint = Blueprint('api', __name__, url_prefix='/api')
-api = Custom_API(blueprint, doc='/docs')
-
+blueprint = Blueprint('api', __name__, url_prefix='/tec-cid/api')
+api = Api(blueprint, doc='/docs')
 app.register_blueprint(blueprint)
 
-CORS(app, resources=r"/api/*", headers="Content-Type")
+CORS(app, resources=r"/tec-cid/api/*", headers="Content-Type")
 
 dao = Dao()
 


### PR DESCRIPTION
Para permitir acesso externo através de um proxy reverso, eu tive que mudar as rotas da API para `/tec-cid/api/...`, com base neste link: https://stackoverflow.com/questions/54837636/how-to-set-base-url-for-swagger-with-flask-restplus

Na VM do tec-cid roda um NGINX. Essa é a configuração que fez funcionar com a nova rota:
```
location /tec-cid/api/ {
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_set_header X-NginX-Proxy true;

        proxy_pass http://localhost:5000/tec-cid/api/;
        proxy_redirect off;
        proxy_intercept_errors on;
        proxy_http_version 1.1;
}
```

E na VM do labdados, que tem acesso externo, tem um servidor Apache com essa configuração para o tec-cid:
```
ProxyPass /tec-cid http://10.10.102.128/tec-cid
ProxyPassReverse /tec-cid http://10.10.102.128/tec-cid
```