### PR TITLE
servidor wsgi sempre local

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.6
-EXPOSE 5000
 LABEL maintainer "Kewyn Akshlley <kewynakshlley@gmail.com>"
-RUN apt-get update
 RUN mkdir /app
 WORKDIR /app
+
+RUN apt-get update
+
 COPY . /app
 RUN pip install --no-cache-dir -r dependencias.txt
+EXPOSE 5000
 CMD python api.py

--- a/backend/api.py
+++ b/backend/api.py
@@ -194,4 +194,4 @@ class Municipios(Resource):
       return jsonify({"dados": municipios})
 
 if __name__ == '__main__':
-   app.run()
+   app.run(host = '0.0.0.0')


### PR DESCRIPTION
Caso as chamadas à app.run() não estejam dentro de  if __name__ == '__main__':  ou em um arquivo separado sempre será iniciado um servidor local, o que não é aconselhável caso um deploy queira ser feito.