### PR TITLE
carregando credenciais do neo4j para script load

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ cp .env.example .env
 docker-compose up
 ```
 
-4. Fazer download dos dados do TCE-PB e TSE; extrair e transformar para criar CSVs no formato adequado e carregar o banco de dados neo4j:
+4. Fazer download dos dados do TCE-PB e TSE; extrair e transformar para criar CSVs no formato adequado e carregar o banco de dados neo4j. Carregue antes o `.env` para obter as credenciais do Neo4j, para que os scripts de load funcionem.
 
 ```
+. .env
 cd database/feed
 python3 download_data_tce.py
 python3 download_data_tse.py
@@ -38,6 +39,13 @@ python3 extract_transform_data_tce.py
 python3 extract_transform_data_tse.py
 python3 load_data_tce.py
 python3 load_data_tse.py
+```
+
+Outra opção, caso as credenciais do neo4j não sejam carregadas do `.env`, é passar as credenciais direto nos scripts de load:
+
+```
+python3 load_data_tce.py <neo4j-user> <neo4j-password>
+python3 load_data_tse.py <neo4j-user> <neo4j-password>
 ```
 
 5. Verificar se tudo ocorreu como esperado acessando a [API](http://localhost:5000/tec-cid/api/docs) e o [browser do neo4j](http://localhost:7474/browser), usando as credenciais especificadas no `.env`

--- a/database/feed/load_data_tce.py
+++ b/database/feed/load_data_tce.py
@@ -1,13 +1,13 @@
+import sys
+from decouple import config
+from etl_utils import query_from_file
 from py2neo import Graph
 
-def query_from_file(neo4j, cypher_file):
-    with open(cypher_file) as f:
-        query = f.read().rstrip("\n")
-        print(query)
-        return neo4j.evaluate(query)
-
 if __name__ == '__main__':
-    neo4j = Graph("localhost", user="neo4j", password="password")
+    user = sys.argv[1] if len(sys.argv) > 1 else config('NEO4J_USER', default='neo4j')
+    password = sys.argv[2] if len(sys.argv) > 2 else config('NEO4J_PASSWORD', default='password')
+    
+    neo4j = Graph("localhost", user=user, password=password)
     cypher_files = [
         'cria_index_unidade_gestora.cypher',
         'cria_index_municipio.cypher',
@@ -15,7 +15,7 @@ if __name__ == '__main__':
         'cria_index_licitacao.cypher',
         'cria_index_participante.cypher',
         'carrega_licitacoes_propostas.cypher',
-        'carrega_municipio.cypher'
+        'carrega_municipios.cypher'
     ]
     
     for cypher_file in cypher_files:

--- a/database/feed/load_data_tse.py
+++ b/database/feed/load_data_tse.py
@@ -1,8 +1,13 @@
+import sys
+from decouple import config
 from etl_utils import query_from_file
 from py2neo import Graph
 
 if __name__ == '__main__':
-    neo4j = Graph("localhost", user="neo4j", password="password")
+    user = sys.argv[1] if len(sys.argv) > 1 else config('NEO4J_USER', default='neo4j')
+    password = sys.argv[2] if len(sys.argv) > 2 else config('NEO4J_PASSWORD', default='password')
+    
+    neo4j = Graph("localhost", user=user, password=password)
     cypher_files = [
         'cria_index_candidato.cypher',
         'cria_index_partido.cypher',

--- a/database/feed/requirements.txt
+++ b/database/feed/requirements.txt
@@ -1,2 +1,3 @@
+decouple
 py2neo
 tqdm


### PR DESCRIPTION
O usuário e senha do neo4j estavam hard-coded nos scripts de carregamento de dados no neo4j. Agora, isto pode ser carregado do `.env` ou passado como parâmetro nos scripts `load_data_tce.py` e `load_data_tse.py`.