### PR TITLE
Adição do algoritmo de Jaccard para obter sócios doadores

### DIFF
--- a/database/feed/cypher/export_doacoes_socios_com_nomes_distintos.cypher
+++ b/database/feed/cypher/export_doacoes_socios_com_nomes_distintos.cypher
@@ -1,23 +1,15 @@
-// O score mínimo do fulltext.queryNodes escolhido foi 1.3, 
-// após realizarmos comparações manuais entre os sócios que eram doadores 
-// e que possuiam uma variação no nome, mas que eram a mesma pessoa.
-//
-// OBS.: O menor score do sócio doador com nome um pouco diferente mas que é a mesma
-// pessoa foi 1.541, já o sócio doador com nome um pouco diferente mas que 
-// não é a mesma pessoa foi 0.925
-
-WITH "MATCH (s:Socio) 
+// Foi utilizado o algoritmo de Jaccard para calcular a similaridade dos nomes
+// dos sócios doadores que possuem o mesmo CPF e nomes diferentes que são a mesma pessoa.
+// Para um relacionamento (Socio)-[:FOI]-(Doador) ser criado, o valor da similaridade dos nomes deverá ser superior a 0.5
+WITH "MATCH (s:Socio)
     WITH s
 
     MATCH (d:Doador)
-    WHERE s.cpf_cnpj = d.cpf_cnpj AND s.nome <> d.nome
-    WITH s, d
-
-    CALL db.index.fulltext.queryNodes('nome_doador', s.nome) YIELD node as doador, score as total
-    WHERE total >= 1.3 AND doador.cpf_cnpj = s.cpf_cnpj AND doador.nome <> s.nome
-
-    WITH s, d, doador, total
-    RETURN s.nome AS nome_socio, s.cpf_cnpj AS cpf_cnpj_socio, d.nome AS nome_doador, d.cpf_cnpj AS cpf_cnpj_doador" AS query
+    WHERE s.cpf_cnpj = d.cpf_cnpj AND s.nome <> d.nome AND split(s.nome, ' ')[0] = split(d.nome, ' ')[0]
+    WITH s, d, toFloat(size(apoc.coll.intersection(split(s.nome, ' '), split(d.nome, ' ')))) / toFloat(size(apoc.coll.union(split(s.nome, ' '), split(d.nome, ' ')))) AS similarity
+    WHERE similarity > 0.5
+    WITH s, d, similarity
+    RETURN s.nome AS nome_socio, s.cpf_cnpj AS cpf_cnpj_socio, d.nome AS nome_doador, d.cpf_cnpj AS cpf_cnpj_doador, similarity" AS query
 
 CALL apoc.export.csv.query(query, "socios_doadores_com_nomes_distintos.csv", {})
 

--- a/database/feed/cypher/rel_doacoes_socios_com_nomes_distintos.cypher
+++ b/database/feed/cypher/rel_doacoes_socios_com_nomes_distintos.cypher
@@ -1,11 +1,13 @@
-USING PERIODIC COMMIT
-LOAD CSV WITH HEADERS FROM "file:///socios_doadores_com_nomes_distintos.csv" AS line
-WITH line
+// Foi utilizado o algoritmo de Jaccard para calcular a similaridade dos nomes
+// dos sócios doadores que possuem o mesmo CPF e nomes diferentes que são a mesma pessoa.
+// Para um relacionamento (Socio)-[:FOI]-(Doador) ser criado, o valor da similaridade dos nomes deverá ser superior a 0.5
+MATCH (s:Socio)
+WITH s
 
-MATCH (s:Socio) WHERE s.cpf_cnpj = line.cpf_cnpj_socio AND s.nome = toUpper(line.nome_socio)
-WITH s, line
-
-MATCH (d:Doador) WHERE d.cpf_cnpj = line.cpf_cnpj_doador AND d.nome = toUpper(line.nome_doador)
+MATCH (d:Doador)
+WHERE s.cpf_cnpj = d.cpf_cnpj AND s.nome <> d.nome AND split(s.nome, ' ')[0] = split(d.nome, ' ')[0]
+WITH s, d, toFloat(size(apoc.coll.intersection(split(s.nome, ' '), split(d.nome, ' ')))) / toFloat(size(apoc.coll.union(split(s.nome, ' '), split(d.nome, ' ')))) AS similarity
+WHERE similarity > 0.5
 WITH s, d
 
 MERGE (s)-[:FOI]->(d);


### PR DESCRIPTION
Agora será utilizado o algoritmo de Jaccard para obter o nível de similaridade dos nomes e poder criar o relacionamento `(Sócio)-[:FOI]->(Doador)` caso o CPF de ambos seja o mesmo e nomes distintos, mas caso o primeiro nome seja igual para ambos e o nível de similaridade de Jaccard maior que 0.5, o relacionamento `(Sócio)-[:FOI]->(Doador)` será criado